### PR TITLE
fixes run_suite issue with subprocess failure to run

### DIFF
--- a/polycrystalx/processes/__init__.py
+++ b/polycrystalx/processes/__init__.py
@@ -1,6 +1,8 @@
 """This is the module for defining and executing model processes"""
-from .. import utils
+import os
+
 from .linear_elasticity import LinearElasticity
+from ..utils import setup_output
 
 
 process_dict = {}
@@ -16,6 +18,6 @@ def run(job):
     job: inputs.job.Job
        the job to run
     """
-    utils.setup_output(job.output_directory)
+    setup_output(job.output_directory)
     process = process_dict[job.process](job)
     process.run()

--- a/polycrystalx/scripts/__init__.py
+++ b/polycrystalx/scripts/__init__.py
@@ -1,0 +1,32 @@
+import sys
+import os
+from pathlib import Path
+from importlib import import_module
+
+
+def get_input_module(imod):
+    """Process input string to get module
+
+    Parameters
+    ----------
+    imod: str or Path
+       name of input module
+
+    RETURNS
+    -------
+    module
+       input module specified by user
+    """
+    # Expect the user to run from directory containing the input module.
+    sys.path.insert(0, str(Path.cwd()))
+
+    # Allow user to specify module by path.
+    if os.path.exists(imod):
+        if imod.endswith("/"):
+            imod = imod[:-1]
+        path, ext = os.path.splitext(imod)
+        imod = path.replace("/", ".")
+
+    user_inputs = import_module(imod)
+
+    return user_inputs

--- a/polycrystalx/scripts/run_job.py
+++ b/polycrystalx/scripts/run_job.py
@@ -3,9 +3,8 @@ import sys
 import argparse
 from pathlib import Path
 
-from dolfinx import log
-
-from polycrystalx import utils, processes
+from polycrystalx import processes
+from . import get_input_module
 
 
 def main():
@@ -13,9 +12,7 @@ def main():
     p = argparser(*sys.argv)
     args = p.parse_args()
 
-    log.set_log_level(log.LogLevel.INFO)
-    user_module = utils.get_input_module(args.input_module)
-    log.set_log_level(log.LogLevel.WARNING)
+    user_module = get_input_module(args.input_module)
     if not hasattr(user_module, "job"):
         raise AttributeError('module has no "jobs" attribute')
 
@@ -33,10 +30,3 @@ def argparser(*args):
     )
 
     return p
-
-
-if __name__ == "__main__":
-    #
-    #  Run problem
-    #
-    main()

--- a/polycrystalx/scripts/run_mpijob.py
+++ b/polycrystalx/scripts/run_mpijob.py
@@ -1,24 +1,24 @@
 """Run a job with MPI"""
 import sys
-import subprocess
 import argparse
 import pickle
 
-from polycrystalx import utils
+from . import get_input_module
 from polycrystalx import processes
 
 
-def main(args):
-    """main program
+def main():
+    """Run a job in MPI"""
+    p = argparser(*sys.argv)
+    args = p.parse_args()
 
-    args - from argparser
-    """
-    user_module = utils.get_input_module(args.input_module)
+    user_module = get_input_module(args.input_module)
     if not hasattr(user_module, "get_job"):
         raise AttributeError('module has no "get_job" attribute')
 
     with open(args.key_file, "rb") as f:
         key = pickle.load(f)
+
     job = user_module.get_job(key)
     processes.run(job)
 
@@ -30,7 +30,7 @@ def argparser(*args):
     )
     p.add_argument(
         'input_module', type=str,
-        help="name of file with serialized JobKey instance"
+        help="name of batch input module"
     )
 
     p.add_argument(
@@ -39,12 +39,3 @@ def argparser(*args):
     )
 
     return p
-
-
-if __name__ == "__main__":
-    #
-    #  Run problem
-    #
-    p = argparser(*sys.argv)
-    args = p.parse_args()
-    main(args)

--- a/polycrystalx/scripts/run_suite.py
+++ b/polycrystalx/scripts/run_suite.py
@@ -8,10 +8,7 @@ import pickle
 
 import numpy as np
 
-from polycrystalx import utils
-
-
-RUN_MPI = pathlib.Path(__file__).parent / "run_mpijob.py"
+from . import get_input_module
 
 
 def main():
@@ -19,7 +16,7 @@ def main():
     p = argparser(*sys.argv)
     args = p.parse_args()
 
-    user_module = utils.get_input_module(args.input_module)
+    user_module = get_input_module(args.input_module)
     if not hasattr(user_module, "job_keys"):
         raise AttributeError('module has no "job_keys" attribute')
 
@@ -27,6 +24,7 @@ def main():
     for job in user_module.job_keys:
         # Pickle to a temp file.
         fp = tempfile.NamedTemporaryFile(delete=False)
+
         with open(fp.name, "wb") as f:
             pickle.dump(job, f)
 
@@ -34,9 +32,8 @@ def main():
         # Now run MPI job.
         cmd = [
             "mpirun", "-np", str(args.n),
-            "python", str(RUN_MPI), args.input_module, fp.name
+            "pxx_mpijob", args.input_module, fp.name
         ]
-        print(f"command is: {' '.join(cmd)}")
         subprocess.run(cmd)
         pathlib.Path(fp.name).unlink()
 
@@ -57,10 +54,3 @@ def argparser(*args):
     )
 
     return p
-
-
-if __name__ == "__main__":
-    #
-    #  Run problem
-    #
-    main()

--- a/polycrystalx/utils/__init__.py
+++ b/polycrystalx/utils/__init__.py
@@ -1,84 +1,14 @@
 """Utilities for handling input"""
-import sys
 import os
-from pathlib import Path
 import time
-from importlib import import_module
 
 import numpy as np
 
 from dolfinx import log
 from dolfinx.fem import assemble_scalar
 
-from mpi4py import MPI
-
 from .xdmffile_ext import XDMFFile_Ext
-
-
-myrank = MPI.COMM_WORLD.rank
-commsize = MPI.COMM_WORLD.size
-
-OFF = log.LogLevel.OFF
-ERROR = log.LogLevel.ERROR
-INFO = log.LogLevel.INFO
-WARNING = log.LogLevel.WARNING
-TAG_SYNC = 500
-
-
-def mpi_sync(from_0=True):
-    """Sync processes
-
-    If we want processes to wait for process 0, we use from_0=True. If we
-    want process 0 to wait for the others, we use from_0=False.
-
-    Parameters
-    ----------
-    from_0: bool, default=True
-       if true, node 0 sends to all other nodes, else other send to 0
-    """
-    # Send random number each time so we can check for matching values.
-    loglevel = WARNING # debugging
-    msg = np.random.random(1)
-    for i in range(1, commsize):
-        if from_0:
-            if myrank == 0:
-                MPI.COMM_WORLD.send(msg, i, tag=TAG_SYNC)
-                log.log(loglevel,
-                        f"0: sending sync from {myrank} to {i}: {msg}"
-                        )
-            if myrank == i:
-                rmsg = MPI.COMM_WORLD.recv(source=0, tag=TAG_SYNC)
-                log.log(loglevel, f"{myrank}: receiving sync from 0: ({rmsg})")
-        else:
-            if myrank == 0:
-                rmsg = MPI.COMM_WORLD.recv(source=i, tag=TAG_SYNC)
-                log.log(loglevel, f"0: receiving sync from {i}: ({rmsg})")
-            if myrank == i:
-                MPI.COMM_WORLD.send(msg, 0, tag=TAG_SYNC)
-                log.log(loglevel, f"{myrank}: sending sync to 0: {msg}")
-
-
-def get_input_module(imod):
-    """Process input string to get module
-
-    Parameters
-    ----------
-    imod: str or Path
-       name of input module
-    """
-    # Expect the user to run from directory containing the input module.
-    sys.path.insert(0, str(Path.cwd()))
-    # Allow user to specify module by path
-    if os.path.exists(imod):
-        if imod.endswith("/"):
-            imod = imod[:-1]
-        path, ext = os.path.splitext(imod)
-        imod = path.replace("/", ".")
-
-    log.log(INFO, f"loading user input module: {imod}")
-    user_inputs = import_module(imod)
-
-    return user_inputs
+from .mpi import MPI, mpi_sync, myrank
 
 
 def setup_output(outdir):
@@ -90,16 +20,16 @@ def setup_output(outdir):
     mpi_sync(from_0=False)
     if not os.path.exists(outdir):
         if myrank == 0:
-            log.log(WARNING, f"creating output directory: {outdir}")
+            log.log(log.LogLevel.INFO, f"creating output directory: {outdir}")
             os.makedirs(outdir)
             time.sleep(0.1)
         mpi_sync()
-    log.log(WARNING, f"{myrank}: changing directory to {outdir}")
+    log.log(log.LogLevel.INFO, f"{myrank}: changing directory to {outdir}")
 
     try:
         os.chdir(outdir)
     except:
-        log.log(WARNING, f"{myrank}: failed to find output directory")
+        raise RuntimeError(f"{myrank}: failed to find output directory")
 
 
 def grain_volumes(comm, gv_form, indicator, grain_cells):

--- a/polycrystalx/utils/mpi.py
+++ b/polycrystalx/utils/mpi.py
@@ -1,0 +1,43 @@
+"""MPI Utilities"""
+import numpy  as np
+
+from dolfinx import log
+from mpi4py import MPI
+
+
+myrank = MPI.COMM_WORLD.rank
+commsize = MPI.COMM_WORLD.size
+TAG_SYNC = 500
+
+
+def mpi_sync(from_0=True):
+    """Sync processes
+
+    If we want processes to wait for process 0, we use from_0=True. If we
+    want process 0 to wait for the others, we use from_0=False.
+
+    Parameters
+    ----------
+    from_0: bool, default=True
+       if true, node 0 sends to all other nodes, else other send to 0
+    """
+    # Send random number each time so we can check for matching values.
+    loglevel = log.LogLevel.INFO
+    msg = np.random.random(1)
+    for i in range(1, commsize):
+        if from_0:
+            if myrank == 0:
+                MPI.COMM_WORLD.send(msg, i, tag=TAG_SYNC)
+                log.log(loglevel,
+                        f"0: sending sync from {myrank} to {i}: {msg}"
+                        )
+            if myrank == i:
+                rmsg = MPI.COMM_WORLD.recv(source=0, tag=TAG_SYNC)
+                log.log(loglevel, f"{myrank}: receiving sync from 0: ({rmsg})")
+        else:
+            if myrank == 0:
+                rmsg = MPI.COMM_WORLD.recv(source=i, tag=TAG_SYNC)
+                log.log(loglevel, f"0: receiving sync from {i}: ({rmsg})")
+            if myrank == i:
+                MPI.COMM_WORLD.send(msg, 0, tag=TAG_SYNC)
+                log.log(loglevel, f"{myrank}: sending sync to 0: {msg}")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ from setuptools import setup, find_packages
 entry_points = {
     'console_scripts': [
         "pxx_job = polycrystalx.scripts.run_job:main",
-        "pxx_suite = polycrystalx.scripts.run_suite:main"
+        "pxx_mpijob = polycrystalx.scripts.run_mpijob:main",
+        "pxx_suite = polycrystalx.scripts.run_suite:main",
     ]
 }
 


### PR DESCRIPTION
This fixes issues with the subprocess module failing to execute the MPI job run from the `run_suite` script.  It seems this has to do with MPI being loaded in the `run_suite` script before `mpirun` was exectuted in the subprocess. This was fixed by removing the dolfinx log import. 

This also includes some reorganization including moving the `setup_output` function to the scripts directory, creating an entry point of `run_mpijob`, and making a separate `mpi` module in the `utils` directory.
